### PR TITLE
FEATURE: Stroke width setting

### DIFF
--- a/javascripts/discourse/api-initializers/lucide-icons.js
+++ b/javascripts/discourse/api-initializers/lucide-icons.js
@@ -1,6 +1,19 @@
 import { apiInitializer } from "discourse/lib/api";
 
 export default apiInitializer((api) => {
+  const strokeWidthMap = {
+    "extra-thin": "1",
+    thin: "1.5",
+    medium: "2",
+    thick: "2.5",
+    "extra-thick": "3",
+  };
+
+  document.documentElement.style.setProperty(
+    "--lucide-icons-stroke-width",
+    strokeWidthMap[settings.stroke_width] || "2"
+  );
+
   api.replaceIcon("align-left", "lc-align-left");
   api.replaceIcon("anchor", "lc-anchor");
   api.replaceIcon("angle-down", "lc-chevron-down");

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,5 +1,5 @@
 en:
   theme_metadata:
-    description: "TODO"
+    description: "Lucide icons for Discourse"
     settings:
       stroke_width: "Controls the thickness of the lines within icons."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,4 +2,4 @@ en:
   theme_metadata:
     description: "TODO"
     settings:
-      example_setting: "A description of a setting."
+      stroke_width: "Controls the thickness of the lines within icons."

--- a/settings.yml
+++ b/settings.yml
@@ -1,2 +1,10 @@
-example_setting:
-  default: true
+stroke_width:
+  default: medium
+  type: enum
+  refresh: true
+  choices:
+    - extra-thin
+    - thin
+    - medium
+    - thick
+    - extra-thick


### PR DESCRIPTION
Adds a theme component setting for specifying the stroke width of the icons.

The `<symbol>` definitions in [icons-sprite.svg](https://github.com/discourse/discourse-lucide-icons/blob/main/assets/icons-sprite.svg) were generated with a stroke width based on a css variable:

```html
<symbol stroke-width="var(--lucide-icons-stroke-width)" ... </symbol>
```

In the initializer, it sets the variable according to the setting value.

---

<img width="765" height="517" alt="image" src="https://github.com/user-attachments/assets/6091972c-9abc-44c3-b8b7-99014486a6f5" />