### PR TITLE
UX: Don't map select icons

### DIFF
--- a/javascripts/discourse/api-initializers/lucide-icons.js
+++ b/javascripts/discourse/api-initializers/lucide-icons.js
@@ -33,7 +33,6 @@ export default apiInitializer((api) => {
     "chart-line": "lc-chart-line",
     "chart-pie": "lc-chart-pie",
     "check": "lc-check",
-    // "circle": "lc-circle", We use the circle icon for a solid dot on unread indicators, so we don't want to replace it with an outlined circular icon
     "circle-check": "lc-circle-check",
     "circle-chevron-down": "lc-circle-chevron-down",
     "circle-minus": "lc-circle-minus",
@@ -230,7 +229,6 @@ export default apiInitializer((api) => {
     "sliders": "lc-sliders-horizontal",
     "sort": "lc-arrow-up-down",
     "spinner": "lc-loader",
-    "square-full": "lc-square",
     "table-cells": "lc-grid-3x3",
     "table-columns": "lc-columns-2",
     "temperature-three-quarters": "lc-thermometer",
@@ -303,7 +301,7 @@ export default apiInitializer((api) => {
     "d-chat": "lc-message-square-text",
     "d-drop-collapsed": "lc-chevron-right",
     "d-drop-expanded": "lc-chevron-down",
-    "d-liked": "lc-heart",
+
     "d-muted": "lc-bell-off",
     "d-post-share": "lc-link",
     "d-regular": "lc-bell",
@@ -352,6 +350,11 @@ export default apiInitializer((api) => {
     "topic.closed": "lc-lock",
     "user_menu.drafts": "lc-pencil",
     "user_menu.replies": "lc-reply",
+
+    //Icons we don't map
+    // "circle": "lc-circle", We use the circle icon for a solid dot, so we don't want to replace it with an outlined icon. We map far-circle to lc-circle instead.
+    // "square-full": "lc-square",  We use the square-full icon for a solid square, so we don't want to replace it with an outlined icon. We map far-square to lc-square instead.
+    // "d-liked": "lc-heart", We want a filled heart for liked, so we only map d-unliked to lc-heart.
   };
 
   Object.entries(iconMappings).forEach(([faIcon, lucideIcon]) => {


### PR DESCRIPTION
Use the filled FA icon for select icons like d-liked and square-full.